### PR TITLE
Set before-save-hook locally, not globally

### DIFF
--- a/py-yapf.el
+++ b/py-yapf.el
@@ -14,7 +14,7 @@
 ;; To automatically apply when saving a python file, use the
 ;; following code:
 
-;;   (add-hook 'before-save-hook 'py-yapf-before-save)
+;;   (add-hook 'python-mode-hook 'py-yapf-enable-on-save)
 
 ;;; Code:
 
@@ -113,15 +113,12 @@ Note that `--in-place' is used by default."
 
 
 ;;;###autoload
-(defun py-yapf-before-save ()
+(defun py-yapf-enable-on-save ()
   "Pre-save hooked to bse used before running py-yapf."
   (interactive)
-  (when (eq major-mode 'python-mode)
-    (condition-case err (py-yapf)
-      (error (message "%s" (error-message-string err))))))
+  (add-hook 'before-save-hook 'py-yapf-buffer nil t))
 
 
 (provide 'py-yapf)
-
 
 ;;; py-yapf.el ends here


### PR DESCRIPTION
This is a neater way to set up the hook, because you don't need to check the mode every time. The error catch-and-rethrow seemed redundant, so I eliminated it.

(Untested, so please give it a quick try!)

In connection with https://github.com/milkypostman/melpa/pull/2665
