### PR TITLE
Let the user customise the name of yapf

### DIFF
--- a/py-yapf.el
+++ b/py-yapf.el
@@ -33,13 +33,19 @@ Note that `--in-place' is used by default."
   :type '(repeat (string :tag "option")))
 
 
+(defcustom py-yapf-command  "yapf"
+  "Name of yapf command to execute."
+  :group 'py-yapf
+  :type '(string))
+
+
 (defun py-yapf--call-executable (errbuf file)
-  (apply 'call-process "yapf" nil errbuf nil
+  (apply 'call-process py-yapf-command nil errbuf nil
          (append py-yapf-options `("--in-place", file))))
 
 
 (defun py-yapf--call ()
-  (py-yapf-bf--apply-executable-to-buffer "yapf" 'py-yapf--call-executable nil "py" t))
+  (py-yapf-bf--apply-executable-to-buffer py-yapf-command 'py-yapf--call-executable nil "py" t))
 
 
 ;;;###autoload


### PR DESCRIPTION
On Debian systems, yapf exists as both yapf for Python 2 and yapf3 for Python 3.  yapf can't format Python 3 as a result; this lets the user select the appropriate yapf for their project.