### PR TITLE
Customize executable

### DIFF
--- a/py-yapf.el
+++ b/py-yapf.el
@@ -25,6 +25,14 @@
   :prefix "py-yapf-")
 
 
+(defcustom py-yapf-executable "yapf"
+  "Name of \"yapf\" executable.
+
+Note that specifying a full path is not supported."
+  :group 'py-yapf
+  :type 'string)
+
+
 (defcustom py-yapf-options nil
   "Options used for yapf.
 
@@ -34,12 +42,12 @@ Note that `--in-place' is used by default."
 
 
 (defun py-yapf--call-executable (errbuf file)
-  (apply 'call-process "yapf" nil errbuf nil
+  (apply 'call-process py-yapf-executable nil errbuf nil
          (append py-yapf-options `("--in-place", file))))
 
 
 (defun py-yapf--call ()
-  (py-yapf-bf--apply-executable-to-buffer "yapf" 'py-yapf--call-executable nil "py" t))
+  (py-yapf-bf--apply-executable-to-buffer py-yapf-executable 'py-yapf--call-executable nil "py" t))
 
 
 ;;;###autoload
@@ -141,7 +149,7 @@ Note that `--in-place' is used by default."
             (progn
               (kill-buffer errbuf)
               (pop kill-ring)
-              (message (format "Buffer is already %sed" executable-name)))
+              (message (format "Buffer needs no processing by \"%s\"." executable-name)))
 
           (if only-on-region
               (py-yapf-bf--replace-region tmpfile)

--- a/py-yapf.el
+++ b/py-yapf.el
@@ -149,7 +149,7 @@ Note that `--in-place' is used by default."
             (progn
               (kill-buffer errbuf)
               (pop kill-ring)
-              (message (format "Buffer needs no processing by \"%s\"." executable-name)))
+              (message (format "Buffer needs no processing by %s." executable-name)))
 
           (if only-on-region
               (py-yapf-bf--replace-region tmpfile)

--- a/py-yapf.el
+++ b/py-yapf.el
@@ -52,7 +52,7 @@ Note that `--in-place' is used by default."
 
 ;;;###autoload
 (defun py-yapf-buffer ()
-  "Uses the \"yapf\" tool to reformat the current buffer."
+  "Use the \"yapf\" tool to reformat the current buffer."
   (interactive)
   (py-yapf--call))
 
@@ -85,7 +85,7 @@ Note that `--in-place' is used by default."
         (goto-char (point-min))
         (while (not (eobp))
           (unless (looking-at "^\\([ad]\\)\\([0-9]+\\) \\([0-9]+\\)")
-            (error "invalid rcs patch or internal error in py-yapf-bf--apply-rcs-patch"))
+            (error "Invalid rcs patch or internal error in py-yapf-bf--apply-rcs-patch"))
           (forward-line)
           (let ((action (match-string 1))
                 (from (string-to-number (match-string 2)))
@@ -108,7 +108,7 @@ Note that `--in-place' is used by default."
                 (kill-whole-line len)
                 (pop kill-ring)))
              (t
-              (error "invalid rcs patch or internal error in py-yapf-bf--apply-rcs-patch")))))))))
+              (error "Invalid rcs patch or internal error in py-yapf-bf--apply-rcs-patch")))))))))
 
 
 (defun py-yapf-bf--replace-region (filename)
@@ -121,7 +121,7 @@ Note that `--in-place' is used by default."
                                            only-on-region
                                            file-extension
                                            ignore-return-code)
-  "Formats the current buffer according to the executable"
+  "Formats the current buffer according to the executable."
   (when (not (executable-find executable-name))
     (error (format "%s command not found." executable-name)))
   ;; Make sure tempfile is an absolute path in the current directory so that


### PR DESCRIPTION
Hi!

This PR allows users to specify the name of an executable that is used instead of the hard-coded `yapf`.  The reasoning behind this is that `yapf` is called `yapf3` on recent Linux distributions based on Ubuntu (and possibly Debian).

Also note that I have changed some strings in the auto-generated part of `py-yapf.el` – mostly to fix some annoying Linter warnings. There is one change that really makes sense, though: `Buffer is already yapf3ed` is a bit irritating. :)

Best regards,

Martin